### PR TITLE
base builds first

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,7 +20,7 @@ endif
 #
 # Define directories to be compile upon a global "make"...
 #
-SUBDIRS := Clustering CosmicRemoval NuTrackRemoval LinearityStudies Base #ADD_NEW_SUBDIR ... do not remove this comment from this line
+SUBDIRS := Base Clustering CosmicRemoval NuTrackRemoval LinearityStudies #ADD_NEW_SUBDIR ... do not remove this comment from this line
 
 
 #####################################################################################


### PR DESCRIPTION
Hi, right now I could not build devel.  I think Base needs to be first in the list of subdirs to be built.

```
twongjirad@tmw-Blade:~/working/larbys/dllee_unified/larlite/UserDev/HitRemoval$ make

Compiling Clustering...
make[1]: Entering directory '/home/twongjirad/working/larbys/dllee_unified/larlite/UserDev/HitRemoval/Clustering'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/home/twongjirad/working/larbys/dllee_unified/larlite/UserDev/HitRemoval/Clustering'

Compiling CosmicRemoval...
make[1]: Entering directory '/home/twongjirad/working/larbys/dllee_unified/larlite/UserDev/HitRemoval/CosmicRemoval'
<< generating libHitRemoval_CosmicRemoval.so >>
/usr/bin/ld: cannot find -lHitRemoval_Base
collect2: error: ld returned 1 exit status
/home/twongjirad/working/larbys/dllee_unified/larlite/Makefile/GNUmakefile.CORE:28: recipe for target '/home/twongjirad/working/larbys/dllee_unified/larlite/lib/libHitRemoval_CosmicRemoval.so' failed
make[1]: *** [/home/twongjirad/working/larbys/dllee_unified/larlite/lib/libHitRemoval_CosmicRemoval.so] Error 1
make[1]: Leaving directory '/home/twongjirad/working/larbys/dllee_unified/larlite/UserDev/HitRemoval/CosmicRemoval'
GNUmakefile:34: recipe for target 'all' failed
make: *** [all] Error 2
```

